### PR TITLE
Child page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ package-lock.json
 .vscode/
 .firebaserc
 firebase.json
-
-*
-!wp-content/themes/e2d3-web

--- a/wp-content/themes/e2d3-web/archive.php
+++ b/wp-content/themes/e2d3-web/archive.php
@@ -1,0 +1,151 @@
+<?php get_header(); ?>
+
+    <main class="main e2d3_archive<?php echo (!is_front_page() && !is_home())?" e2d3_child":""; ?>">
+<!-- アーカイブ -->
+      <section class="module e2d3-page-content">
+        <div class="module-inner">
+
+          <?php if ( have_posts() ) { ?>
+
+            <header class="page-header">
+
+							<h1 class="page-title">
+                <span><?php
+                  if(is_month()){
+                    echo '月別: '.get_query_var('year').'年'.get_query_var('monthnum').'月';
+                  }else if(is_tag()){
+                    echo 'タグ: ';
+                    single_cat_title();
+                  }else{
+                    echo 'カテゴリー: ';
+                    single_cat_title();
+                  }
+                  ?></span>
+							</h1>
+
+						</header><!-- .page-header -->
+
+          <?php if(have_posts()): while(have_posts()): the_post(); ?>
+            <article <?php post_class("entry"); ?>>
+
+              <?php
+              // サムネ
+              $post_thumbnail_url = get_the_post_thumbnail( get_the_ID(), 'e2d3-post-thumbnail' );
+
+          		if ( ! empty( $post_thumbnail_url ) ) {
+
+          			echo '<div class="post-img-wrap">';
+
+                $image_id = get_post_thumbnail_id();
+                $image_url = wp_get_attachment_image_src($image_id, true);
+
+          			echo '<a href="' . esc_url( get_permalink() ) . '" title="' . the_title_attribute( 'echo=0' ) . '">';
+
+
+                  echo $post_thumbnail_url;
+
+          				echo '</a>';
+
+          			echo '</div>';
+
+          			echo '<div class="listpost-content-wrap">';
+          		} else {
+
+          			echo '<div class="listpost-content-wrap-full">';
+          		}
+
+              ?>
+
+              <div class="list-post-top">
+
+              <!-- タイトルなど -->
+            	<header class="entry-header">
+
+            		<h1 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
+
+            		<?php if ( 'post' == get_post_type() ) : ?>
+
+                <!-- 投稿日 -->
+            		<div class="entry-meta">
+
+                  <?php echo '('.get_post_time('Y/m/d').')'; ?>
+
+            		</div><!-- .entry-meta -->
+
+            		<?php endif; ?>
+
+            	</header><!-- .entry-header -->
+
+              <!-- 抜粋 -->
+              <div class="entry-content">
+
+              <a href="<?php echo esc_url( get_permalink()); ?>" title="<?php echo the_title_attribute( 'echo=0' ); ?>" class="entry-description">
+              <?php
+
+            		$ismore = ! empty( $post->post_content ) ? strpos( $post->post_content, '<!--more-->' ) : '';
+
+                if ( ! empty( $ismore ) ) {
+            			the_content("&hellip;");
+            		} else {
+            			the_excerpt();
+            		}
+               ?>
+             </a>
+
+             </div>
+             <footer class="entry-footer">
+
+               <?php
+               if ( 'post' == get_post_type() ) {
+
+                 $categories_list = get_the_category_list(', ');
+
+                 if ( $categories_list ) {
+
+                   echo '<span class="cat-links">';
+
+                  echo "カテゴリー: ".$categories_list;
+
+                   echo '</span>';
+
+                 }
+
+                 $tags_list = get_the_tag_list('',', ');
+
+                 if ( $tags_list ) {
+
+                   echo '<span class="tags-links">';
+
+                  echo "タグ: ".$tags_list;
+
+                   echo '</span>';
+
+                 }
+               }
+
+               ?>
+
+             </footer>
+
+           </article>
+          <?php endwhile; endif; ?>
+        <?php } else {
+          echo "ありません";
+        }
+        ?>
+        </div>
+      </section>
+<!-- サイドバー -->
+      <section class="sidebar-wrap col-md-3 clear-fix content-left-wrap module e2d3-sidebar">
+          <div class="widget-area module-inner">
+            <?php
+              if(is_active_sidebar('e2d3_child_page_sidebar')){
+                dynamic_sidebar('e2d3_child_page_sidebar');
+              }
+             ?>
+          </div>
+        </section>
+
+    </main>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/e2d3-web/front-page.php
+++ b/wp-content/themes/e2d3-web/front-page.php
@@ -1,5 +1,5 @@
 <?php get_header(); ?>
-    
+
     <main class="main">
 
         <section class="module main-intro">
@@ -18,13 +18,11 @@
         </section>
 
         <section class="module main-news">
-            <div class="module-inner">
-                <dl>
-                    <dt>News</dt>
-                    <dd><a>2018/04/01　Webページをリニューアルしました。</a></dd>
-                    <dd><a href="#">2018/04/01　一二三四五六七八九〇一二三四五六七八九〇一二三四五六七八九〇一二三四五六七八九〇</a></dd>
-                </dl>
-            </div>
+          <div class="module-inner">
+            <?php
+              show_news();
+            ?>
+          </div>
         </section>
 
         <section class="module main-about" id="anchor-about">
@@ -160,39 +158,16 @@
                 <p class="large-txt">一緒にデータビジュアライズを楽しみませんか？</p>
                 <p>E2D3は、データビジュアライゼーションの最新情報を共有するだけでなく、誰もがデータビジュアライゼーションを学び、楽しめるイベントを開催しています。ゲストを招いての講演会やワークショップ、ハッカソンなど開催中！<br>エンジニアだけでなく、デザイナーや営業、主婦、小学生、大学生など様々なバックグラウンドの方に楽しんでいただいてます。データビジュアライズに興味がある方大歓迎！ぜひお気軽にご参加ください。</p>
 
-                <ul class="eventInfo-coming">
-                    <li><a href="#">
-                        <div class="event-date">
-                            <span class="date-year">2018</span>
-                            <span class="date-day">04/05(金)<br>13:00〜</span>
-                            <span class="date-place">渋谷TechPlay</span>
-                        </div>
-                        <div class="event-description">
-                            <div class="desc-tag">
-                                <span class="tag">もくもく会</span>
-                                <span class="tag open">予約受付中</span>
-                            </div>
-                            <h3 class="desc-eventTitle">もくもく会＆LT会【要予約】</h3>
-                            <p class="desc-text">誰もがData Vizを簡単に楽しめる世界を目指すグラフ共有コミュニティE2D3（Excel to D3.js）と一緒に、最新のデータビジュアライゼーションを勉強しませんか。どなたでも参加できます。</p>
-                        </div>
-                    </a></li>
-                    <li><a href="#">
-                        <div class="event-date">
-                            <span class="date-year">2018</span>
-                            <span class="date-day">04/05(金)<br>13:00〜</span>
-                            <span class="date-place">長い名前の開催場所長い開催場所名</span>
-                        </div>
-                        <div class="event-description">
-                            <div class="desc-tag">
-                                <span class="tag">講演会</span>
-                                <span class="tag closed">受付終了</span>
-                            </div>
-                            <h3 class="desc-eventTitle">もくもく会＆LT会【要予約】</h3>
-                            <p class="desc-text">誰もがData Vizを簡単に楽しめる世界を目指すグラフ共有コミュニティE2D3（Excel to D3.js）と一緒に、最新のデータビジュアライゼーションを勉強しませんか。どなたでも参加できます。</p>
-                        </div>
-                    </a></li>
-                </ul>
 
+                <?php
+                include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+                if(is_plugin_active('e2d3-event-info/e2d3-event-info.php')){
+                  Event_Info_E2D3::show_event_list();
+                }
+
+                ?>
+
+                
                 <h3>過去のイベント</h3>
                 <ul class="eventInfo-past"><!--
                  --><li><a href="#" style="background-image:url('http://e2d3.org/wp-content/uploads/2017/11/23032921_10214709510551805_3844396104476802665_n.jpg')">
@@ -258,7 +233,7 @@
                         <li><a href="https://github.com/e2d3/e2d3">Source Code</a></li>
                         <li><a href="https://github.com/e2d3/e2d3/wiki/Home_ja">Wiki</a></li>
                     </ul>
-                    
+
                 </div>
             </div>
         </section>

--- a/wp-content/themes/e2d3-web/functions.php
+++ b/wp-content/themes/e2d3-web/functions.php
@@ -1,0 +1,89 @@
+<?php
+
+// サイドバーを有効に
+add_action( 'widgets_init', 'e2d3_register_widget');
+// 追加のCSSやJSなど
+add_action('wp_enqueue_scripts', 'add_e2d3_style');
+// 検索結果に、カスタム投稿を出さないように
+add_filter( 'pre_get_posts', 'search_exclude_custom_post_type' );
+// 検索結果を新しい順にする
+add_filter('posts_search_orderby', 'custom_posts_search_orderby');
+// アーカイブページで「もっと読む」にあたる部分
+add_filter('excerpt_more', 'new_excerpt_more');
+// サムネイルを250＊250で作る
+add_theme_support( 'post-thumbnails' );
+add_image_size( 'e2d3-post-thumbnail', 250, 250, true );
+
+function e2d3_register_widget() {
+
+		register_sidebar(
+			array(
+				'name'          => '子ページ用サイドMENU',
+				'id'            => 'e2d3_child_page_sidebar',
+				'before_widget' => '<aside id="%1$s" class="widget %2$s">',
+				'after_widget' => '</aside>',
+				'before_title' => '<h2 class="widget-title">',
+				'after_title' => '</h2>',
+			)
+		);
+
+}
+
+function add_e2d3_style(){
+  // 子ページだったら
+  if(!is_front_page() && !is_home()){
+    wp_enqueue_style(
+      'e2d3_widget_style',
+      get_stylesheet_directory_uri().'/style-child.css',
+      false,
+      null
+    );
+  }
+
+}
+
+function search_exclude_custom_post_type( $query ) {
+	if ( $query->is_search() && $query->is_main_query() && ! is_admin() ) {
+		$query->set( 'post_type', array( 'post', 'page' ) );
+	}
+}
+
+function new_excerpt_more($more) {
+	return '&hellip;';
+}
+
+function custom_posts_search_orderby() {
+    return ' post_date desc ';
+}
+
+// トップページの「News」
+function show_news(){
+
+	$qNews = new WP_Query(array(
+		'category_name'=>'News',
+		'post_status'=>'publish',
+		'orderby'=>'date',
+		'order'=>'DESC',
+		'posts_per_page'=>'2'
+	));
+
+	if($qNews->have_posts()):
+		?>
+		<dl>
+			<dt>News</dt>
+		<?php while($qNews->have_posts()):$qNews->the_post(); ?>
+			<dd><a href="<?php the_permalink(); ?>"><?php
+			echo get_post_time('Y/m/d').'　';
+			the_title();
+			 ?></a></dd>
+		<?php endwhile; ?>
+		</dl>
+	<?php else: ?>
+		<!-- Newsが無かった場合 -->
+
+	<?php
+				endif;
+	wp_reset_postdata();
+}
+
+?>

--- a/wp-content/themes/e2d3-web/search.php
+++ b/wp-content/themes/e2d3-web/search.php
@@ -1,0 +1,178 @@
+<?php get_header(); ?>
+
+    <main class="main e2d3_archive<?php echo (!is_front_page() && !is_home())?" e2d3_child":""; ?>">
+<!-- アーカイブ -->
+      <section class="module e2d3-page-content">
+        <div class="module-inner">
+
+          <?php if ( have_posts() ) { ?>
+
+            <header class="page-header">
+
+							<h1 class="page-title">
+                <span><?php
+                if ( ! is_search() ) {
+
+                  if(is_month()){
+                    echo '月別: '.get_query_var('year').'年'.get_query_var('monthnum').'月';
+                  }else{
+                    echo 'カテゴリー: ';
+                    single_cat_title();
+                  }
+                } else {
+                  echo '検索結果: '.get_search_query();
+                }
+
+
+                  ?></span>
+							</h1>
+
+						</header><!-- .page-header -->
+
+          <?php if(have_posts()): while(have_posts()): the_post(); ?>
+            <article <?php post_class("entry"); ?>>
+
+              <?php
+              // サムネ
+              $post_thumbnail_url = get_the_post_thumbnail( get_the_ID(), 'e2d3-post-thumbnail' );
+
+          		if ( ! empty( $post_thumbnail_url ) ) {
+
+          			echo '<div class="post-img-wrap">';
+
+                $image_id = get_post_thumbnail_id();
+                $image_url = wp_get_attachment_image_src($image_id, true);
+
+          			echo '<a href="' . esc_url( get_permalink() ) . '" title="' . the_title_attribute( 'echo=0' ) . '">';
+
+
+                  echo $post_thumbnail_url;
+
+          				echo '</a>';
+
+          			echo '</div>';
+
+          			echo '<div class="listpost-content-wrap">';
+          		} else {
+
+          			echo '<div class="listpost-content-wrap-full">';
+          		}
+
+              ?>
+
+              <div class="list-post-top">
+
+              <!-- タイトルなど -->
+            	<header class="entry-header">
+
+            		<h1 class="entry-title"><a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a></h1>
+
+            		<?php if ( 'post' == get_post_type() ) : ?>
+
+                <!-- 投稿日 -->
+            		<div class="entry-meta">
+
+                  <?php echo '('.get_post_time('Y/m/d').')'; ?>
+
+            		</div><!-- .entry-meta -->
+
+            		<?php endif; ?>
+
+            	</header><!-- .entry-header -->
+
+              <!-- 抜粋 -->
+              <div class="entry-content">
+
+              <a href="<?php echo esc_url( get_permalink()); ?>" title="<?php echo the_title_attribute( 'echo=0' ); ?>" class="entry-description">
+              <?php
+
+            		$ismore = ! empty( $post->post_content ) ? strpos( $post->post_content, '<!--more-->' ) : '';
+
+                if ( ! empty( $ismore ) ) {
+            			the_content("&hellip;");
+            		} else {
+            			the_excerpt();
+            		}
+               ?>
+             </a>
+
+               <footer class="entry-footer">
+
+             		<?php
+             		if ( 'post' == get_post_type() ) {
+
+             			$categories_list = get_the_category_list(', ');
+
+             			if ( $categories_list ) {
+
+             				echo '<span class="cat-links">';
+
+                    echo "カテゴリー: ".$categories_list;
+
+             				echo '</span>';
+
+             			}
+
+             			$tags_list = get_the_tag_list('',', ');
+
+             			if ( $tags_list ) {
+
+             				echo '<span class="tags-links">';
+
+                    echo "タグ: ".$tags_list;
+
+             				echo '</span>';
+
+             			}
+             		}
+
+             		?>
+
+             	</footer>
+
+             </div>
+
+           </article>
+          <?php endwhile; endif; ?>
+        <?php } else {
+        ?>
+        <header class="page-header">
+
+          <h1 class="page-title">
+            <span>見つかりません</span>
+          </h1>
+
+        </header><!-- .page-header -->
+        <div class="page-content">
+
+
+        			<p>ご指定の検索条件に一致する投稿がありませんでした。他のキーワードでもう一度検索してみてください。</p>
+
+        			<form role="search" method="get" class="search-form" action="<?php echo home_url('/'); ?>">
+        				<label>
+        					<span class="screen-reader-text">検索:</span>
+        					<input type="search" class="search-field" placeholder="検索 …" name="s">
+        				</label>
+        				<input type="submit" class="search-submit" value="検索">
+        			</form>
+
+        	</div>
+        <?php
+        }
+        ?>
+        </div>
+      </section>
+<!-- サイドバー -->
+      <section class="sidebar-wrap col-md-3 clear-fix content-left-wrap module e2d3-sidebar">
+          <div class="widget-area module-inner">
+            <?php
+              if(is_active_sidebar('e2d3_child_page_sidebar')){
+                dynamic_sidebar('e2d3_child_page_sidebar');
+              }
+             ?>
+          </div>
+        </section>
+
+    </main>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/e2d3-web/searchform.php
+++ b/wp-content/themes/e2d3-web/searchform.php
@@ -1,0 +1,7 @@
+<form method="get" class="search-form" action="<?php echo esc_url(home_url('/')); ?>">
+  <label>
+		<span class="screen-reader-text">検索:</span>
+		<input type="search" class="search-field" placeholder="検索 …" name="s">
+	</label>
+	<input type="submit" class="search-submit" value="検索">
+</form>

--- a/wp-content/themes/e2d3-web/singular.php
+++ b/wp-content/themes/e2d3-web/singular.php
@@ -1,0 +1,41 @@
+<?php get_header(); ?>
+
+    <main class="main<?php echo (!is_front_page() && !is_home())?" e2d3_child":""; ?>">
+      <section class="module e2d3-page-content">
+        <div class="module-inner">
+
+          <?php if(have_posts()): while(have_posts()): the_post(); ?>
+            <div class="entry">
+              <h1 class="entry-title"><?php the_title(); ?></h1>
+
+              <?php if(!is_page()): ?>
+
+              <!-- 投稿日 -->
+              <div class="entry-meta">
+
+                <?php echo '('.get_post_time('Y/m/d').')'; ?>
+
+              </div><!-- .entry-meta -->
+              <?php endif; ?>
+              <div class="entry-content">
+                <?php the_content(); ?>
+              </div>
+            </div>
+          <?php endwhile; endif; ?>
+
+        </div>
+      </section>
+
+      <section class="sidebar-wrap col-md-3 clear-fix content-left-wrap module e2d3-sidebar">
+          <div class="widget-area module-inner">
+            <?php
+              if(is_active_sidebar('e2d3_child_page_sidebar')){
+                dynamic_sidebar('e2d3_child_page_sidebar');
+              }
+             ?>
+          </div>
+        </section>
+
+    </main>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/e2d3-web/src/style-child.scss
+++ b/wp-content/themes/e2d3-web/src/style-child.scss
@@ -1,0 +1,434 @@
+$breakpoint: (
+  sp: "only screen and (max-width: 760px)",
+  pc: "only screen and (min-width: 761px)"
+);
+
+@mixin media ($device) {
+  @media #{map-get($breakpoint, $device)} {
+    @content;
+  }
+}
+
+@mixin clearfix{
+  &::after{
+    content: "";
+    display: block;
+    clear: both;
+  }
+}
+
+// 子ページ用に上書き
+.e2d3_child{
+
+  *,*:before,*:after{
+      box-sizing: border-box;
+  }
+
+  p{
+    margin: 0 0 24px;
+  }
+  img {
+      max-width: 100%;
+      height: auto;
+  }
+  hr {
+      height: 1px;
+      margin-bottom: 1.5em;
+      border: 0;
+      background-color: #ccc;
+  }
+
+  .clear-fix:after{
+    content: "";
+    display: block;
+    clear: both;
+  }
+
+  @include media("pc"){
+    width: 100%;
+    max-width: 1170px;
+    margin: 0 auto;
+    margin-bottom: 100px;
+    overflow: auto;
+    padding-top: 80px;
+  }
+
+  .module{
+    @include media("pc"){
+      border-bottom: none;
+    }
+  }
+
+  .module-inner{
+    padding-bottom: 0;
+    padding-top: 50px;
+    @include media("pc"){
+      max-width: inherit;
+      padding-top: 0;
+    }
+  }
+  .e2d3-page-content{
+    @include media("pc"){
+      width: 75%;
+      float: left;
+    }
+  }
+  .e2d3-sidebar{
+    @include media("pc"){
+      width: 25%;
+      float: left;
+      border-left: 1px solid rgba(0, 0, 0, 0.05);
+    }
+  }
+  // 主に不具合報告
+  select,textarea{
+    width: 100%;
+  }
+  select{
+    padding: 5px;
+  }
+  textarea{
+    padding: 10px;
+  }
+  input[type="submit"].wpcf7-submit{
+    width: 100%;
+    margin: 0;
+    display: block;
+    @include media("pc"){
+      margin: 0 auto;
+      width: 200px;
+    }
+  }
+  input[type="submit"].wpcf7-submit:hover{
+    opacity: 0.8;
+    transition-duration: 0.4s;
+  }
+
+  input[type="text"], input[type="email"], input[type="url"], input[type="password"], input[type="search"], textarea {
+      border: 1px solid rgba(0, 0, 0, 0.1);
+      border-radius: 0;
+      color: #555;
+  }
+  input[type="search"] {
+      -webkit-box-sizing: content-box;
+      -moz-box-sizing: content-box;
+      box-sizing: content-box;
+      -webkit-appearance: textfield;
+  }
+  button, input[type="button"], input[type="reset"], input[type="submit"] {
+      margin: 10px;
+      padding: 13px 35px 13px 35px;
+      border: none;
+      border-radius: 4px;
+      color: #fff;
+      background-color: #e96656;
+      box-shadow: none;
+      text-shadow: none;
+      font-size: 14px;
+      font-weight: 400;
+      text-align: center;
+      vertical-align: middle;
+      white-space: nowrap;
+      text-transform: uppercase;
+      cursor: pointer;
+  }
+  .screen-reader-text {
+      clip: rect(1px, 1px, 1px, 1px);
+      position: absolute;
+  }
+}
+.entry{
+  overflow: hidden;
+}
+.entry-title {
+    padding-top: 0;
+    font-size: 20px;
+    position: relative;
+    font-weight: 700;
+    color: #404040;
+    font-size: 20px;
+    line-height: 22px;
+    a{
+      color: #404040;
+      font-size: 20px;
+      line-height: 22px;
+    }
+    &:before{
+      position: absolute;
+      z-index: 1;
+      bottom: -9px;
+      left: 0;
+      width: 10%;
+      height: 2px;
+      margin: auto;
+      background: #e96656;
+      content: "";
+    }
+    &:after{
+      position: absolute;
+      z-index: 1;
+      bottom: -9px;
+      left: 0;
+      width: 10%;
+      height: 2px;
+      margin: auto;
+      background: #e96656;
+      content: "";
+    }
+}
+.entry-meta{
+  margin-top: 10px;
+}
+.entry-content {
+    line-height: 20px;
+    margin: 50px 0 0;
+    h3{
+      font-size: 20px;
+      margin-bottom: 30px;
+      font-weight: bold;
+    }
+    h4{
+      margin-bottom: 1em;
+      font-weight: bold;
+    }
+    a{
+      display: inline-block;
+    }
+}
+
+
+
+
+
+// サイドバー
+.widget-area {
+    float: left;
+    width: 100%;
+
+  .widget {
+    clear: both;
+  }
+  // 検索
+  .widget_search{
+
+    form {
+      position: relative;
+    }
+    label {
+      position: relative;
+      width: 100%;
+      margin-bottom: 5px;
+    }
+    input{
+      width: 83%;
+      padding: 12px 15% 12px 2%;
+    }
+
+
+    .search-submit {
+        display: block;
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 46px;
+        height: 46px;
+        margin: 0;
+        padding: 0;
+        background: url(images/search_icon.png) no-repeat center center;
+        text-indent: -9999999px;
+    }
+
+  }
+
+  .widget-title {
+      float: none;
+      position: relative;
+      margin-top: 30px;
+      margin-bottom: 30px;
+      padding-bottom: 5px;
+      color: #404040;
+      font-size: 17px;
+      font-weight: bold;
+      text-align: left;
+      text-transform: uppercase;
+      &:before{
+        position: absolute;
+        z-index: 1;
+        bottom: -9px;
+        left: 0;
+        width: 35%;
+        height: 2px;
+        margin: auto;
+        background: #e96656;
+        content: "";
+      }
+  }
+
+  ul {
+      display: block;
+      margin: 0;
+      padding: 0;
+      li {
+          position: relative;
+          margin: 15px 0;
+          margin-left: 3%;
+          padding-left: 10px;
+          text-align: left;
+          list-style: none;
+          &:before{
+            float: left;
+            position: absolute;
+            left: 0;
+            width: 4px;
+            height: 4px;
+            margin-top: 11px;
+            background: #e9e9e9;
+            content: "";
+          }
+          a{
+            color: #808080;
+            text-decoration: none;
+            transition: all 700ms;
+            &:hover{
+              color: #404040;
+            }
+          }
+      }
+  }
+
+}
+
+// アーカイブ
+.page-header {
+    margin: 0 0 40px;
+    border-bottom: none;
+    text-align: left;
+    padding-bottom: 9px;
+    .page-title {
+        position: relative;
+        font-size: 24px;
+        font-weight: bold;
+        &:before {
+            position: absolute;
+            z-index: 1;
+            bottom: -9px;
+            left: 0;
+            width: 35%;
+            height: 2px;
+            margin: auto;
+            background: #e9e9e9;
+            content: "";
+        }
+    }
+}
+
+.listpost-content-wrap {
+    float: left;
+    width: 100%;
+    margin-top: 20px;
+    @include media("pc"){
+      float: none;
+      margin-top: 0;
+    }
+}
+
+// サムネイル
+.post-img-wrap {
+    display: inline-block;
+    float: left;
+    overflow: hidden;
+    text-align: center;
+    width: 100%;
+    @include media("pc"){
+      width: auto;
+      margin-right: 20px;
+    }
+    a {
+        float: none;
+        width: 250px;
+        height: 250px;
+        margin: 0 auto;
+        display: inline-block;
+        background-size: cover;
+        position: relative;
+        background-position: center;
+        overflow: hidden;
+        @include media("pc"){
+          width: 200px;
+          height: 200px;
+        }
+        img {
+          position: absolute;
+          max-width: initial;
+          top: 50%;
+          left: 50%;
+          height: 100%;
+          width: auto;
+          transform: translate(-50%,-50%);
+          transition-duration: 0.4s;
+        }
+        &:hover img{
+          transform: translate(-50%,-50%) scale(1.1);
+        }
+    }
+}
+
+.e2d3_archive{
+
+  .module{
+    border-bottom: none;
+  }
+
+  .entry{
+    overflow: hidden;
+    margin-bottom: 30px;
+    padding-bottom: 30px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+  }
+
+  .entry-header{
+    overflow: hidden;
+  }
+
+  .entry-title a:hover{
+    text-decoration: none;
+    color: #20A75E;
+  }
+  .entry-content{
+    margin-top: 1em;
+    overflow: hidden;
+  }
+  .entry-description{
+    color: #333;
+    &:hover{
+      color: #20A75E;
+      text-decoration: none;
+    }
+  }
+  .entry-footer{
+    @include media("pc"){
+      padding-top: 10px;
+    }
+     a{
+      font-style: italic;
+      &:hover{
+        text-decoration: none;
+      }
+    }
+
+  }
+
+}
+
+// 検索結果
+.search-form{
+  text-align: center;
+}
+.search-field{
+  width: 96%;
+  padding: 12px 2% 12px 2%;
+}
+
+footer{
+  clear: both;
+}

--- a/wp-content/themes/e2d3-web/style-child.css
+++ b/wp-content/themes/e2d3-web/style-child.css
@@ -1,0 +1,433 @@
+.e2d3_child *, .e2d3_child *:before, .e2d3_child *:after {
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
+}
+
+.e2d3_child p {
+  margin: 0 0 24px;
+}
+
+.e2d3_child img {
+  max-width: 100%;
+  height: auto;
+}
+
+.e2d3_child hr {
+  height: 1px;
+  margin-bottom: 1.5em;
+  border: 0;
+  background-color: #ccc;
+}
+
+.e2d3_child .clear-fix:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.e2d3_child .module-inner {
+  padding-bottom: 0;
+  padding-top: 50px;
+}
+
+.e2d3_child select, .e2d3_child textarea {
+  width: 100%;
+}
+
+.e2d3_child select {
+  padding: 5px;
+}
+
+.e2d3_child textarea {
+  padding: 10px;
+}
+
+.e2d3_child input[type="submit"].wpcf7-submit {
+  width: 100%;
+  margin: 0;
+  display: block;
+}
+
+.e2d3_child input[type="submit"].wpcf7-submit:hover {
+  opacity: 0.8;
+  -webkit-transition-duration: 0.4s;
+       -o-transition-duration: 0.4s;
+          transition-duration: 0.4s;
+}
+
+.e2d3_child input[type="text"], .e2d3_child input[type="email"], .e2d3_child input[type="url"], .e2d3_child input[type="password"], .e2d3_child input[type="search"], .e2d3_child textarea {
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0;
+  color: #555;
+}
+
+.e2d3_child input[type="search"] {
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+  -webkit-appearance: textfield;
+}
+
+.e2d3_child button, .e2d3_child input[type="button"], .e2d3_child input[type="reset"], .e2d3_child input[type="submit"] {
+  margin: 10px;
+  padding: 13px 35px 13px 35px;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  background-color: #e96656;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  text-shadow: none;
+  font-size: 14px;
+  font-weight: 400;
+  text-align: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.e2d3_child .screen-reader-text {
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute;
+}
+
+.entry {
+  overflow: hidden;
+}
+
+.entry-title {
+  padding-top: 0;
+  font-size: 20px;
+  position: relative;
+  font-weight: 700;
+  color: #404040;
+  font-size: 20px;
+  line-height: 22px;
+}
+
+.entry-title a {
+  color: #404040;
+  font-size: 20px;
+  line-height: 22px;
+}
+
+.entry-title:before {
+  position: absolute;
+  z-index: 1;
+  bottom: -9px;
+  left: 0;
+  width: 10%;
+  height: 2px;
+  margin: auto;
+  background: #e96656;
+  content: "";
+}
+
+.entry-title:after {
+  position: absolute;
+  z-index: 1;
+  bottom: -9px;
+  left: 0;
+  width: 10%;
+  height: 2px;
+  margin: auto;
+  background: #e96656;
+  content: "";
+}
+
+.entry-meta {
+  margin-top: 10px;
+}
+
+.entry-content {
+  line-height: 20px;
+  margin: 50px 0 0;
+}
+
+.entry-content h3 {
+  font-size: 20px;
+  margin-bottom: 30px;
+  font-weight: bold;
+}
+
+.entry-content h4 {
+  margin-bottom: 1em;
+  font-weight: bold;
+}
+
+.entry-content a {
+  display: inline-block;
+}
+
+.widget-area {
+  float: left;
+  width: 100%;
+}
+
+.widget-area .widget {
+  clear: both;
+}
+
+.widget-area .widget_search form {
+  position: relative;
+}
+
+.widget-area .widget_search label {
+  position: relative;
+  width: 100%;
+  margin-bottom: 5px;
+}
+
+.widget-area .widget_search input {
+  width: 83%;
+  padding: 12px 15% 12px 2%;
+}
+
+.widget-area .widget_search .search-submit {
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 46px;
+  height: 46px;
+  margin: 0;
+  padding: 0;
+  background: url(images/search_icon.png) no-repeat center center;
+  text-indent: -9999999px;
+}
+
+.widget-area .widget-title {
+  float: none;
+  position: relative;
+  margin-top: 30px;
+  margin-bottom: 30px;
+  padding-bottom: 5px;
+  color: #404040;
+  font-size: 17px;
+  font-weight: bold;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.widget-area .widget-title:before {
+  position: absolute;
+  z-index: 1;
+  bottom: -9px;
+  left: 0;
+  width: 35%;
+  height: 2px;
+  margin: auto;
+  background: #e96656;
+  content: "";
+}
+
+.widget-area ul {
+  display: block;
+  margin: 0;
+  padding: 0;
+}
+
+.widget-area ul li {
+  position: relative;
+  margin: 15px 0;
+  margin-left: 3%;
+  padding-left: 10px;
+  text-align: left;
+  list-style: none;
+}
+
+.widget-area ul li:before {
+  float: left;
+  position: absolute;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  margin-top: 11px;
+  background: #e9e9e9;
+  content: "";
+}
+
+.widget-area ul li a {
+  color: #808080;
+  text-decoration: none;
+  -webkit-transition: all 700ms;
+  -o-transition: all 700ms;
+  transition: all 700ms;
+}
+
+.widget-area ul li a:hover {
+  color: #404040;
+}
+
+.page-header {
+  margin: 0 0 40px;
+  border-bottom: none;
+  text-align: left;
+  padding-bottom: 9px;
+}
+
+.page-header .page-title {
+  position: relative;
+  font-size: 24px;
+  font-weight: bold;
+}
+
+.page-header .page-title:before {
+  position: absolute;
+  z-index: 1;
+  bottom: -9px;
+  left: 0;
+  width: 35%;
+  height: 2px;
+  margin: auto;
+  background: #e9e9e9;
+  content: "";
+}
+
+.listpost-content-wrap {
+  float: left;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.post-img-wrap {
+  display: inline-block;
+  float: left;
+  overflow: hidden;
+  text-align: center;
+  width: 100%;
+}
+
+.post-img-wrap a {
+  float: none;
+  width: 250px;
+  height: 250px;
+  margin: 0 auto;
+  display: inline-block;
+  background-size: cover;
+  position: relative;
+  background-position: center;
+  overflow: hidden;
+}
+
+.post-img-wrap a img {
+  position: absolute;
+  max-width: initial;
+  top: 50%;
+  left: 50%;
+  height: 100%;
+  width: auto;
+  -webkit-transform: translate(-50%, -50%);
+      -ms-transform: translate(-50%, -50%);
+          transform: translate(-50%, -50%);
+  -webkit-transition-duration: 0.4s;
+       -o-transition-duration: 0.4s;
+          transition-duration: 0.4s;
+}
+
+.post-img-wrap a:hover img {
+  -webkit-transform: translate(-50%, -50%) scale(1.1);
+      -ms-transform: translate(-50%, -50%) scale(1.1);
+          transform: translate(-50%, -50%) scale(1.1);
+}
+
+.e2d3_archive .module {
+  border-bottom: none;
+}
+
+.e2d3_archive .entry {
+  overflow: hidden;
+  margin-bottom: 30px;
+  padding-bottom: 30px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+}
+
+.e2d3_archive .entry-header {
+  overflow: hidden;
+}
+
+.e2d3_archive .entry-title a:hover {
+  text-decoration: none;
+  color: #20A75E;
+}
+
+.e2d3_archive .entry-content {
+  margin-top: 1em;
+  overflow: hidden;
+}
+
+.e2d3_archive .entry-description {
+  color: #333;
+}
+
+.e2d3_archive .entry-description:hover {
+  color: #20A75E;
+  text-decoration: none;
+}
+
+.e2d3_archive .entry-footer a {
+  font-style: italic;
+}
+
+.e2d3_archive .entry-footer a:hover {
+  text-decoration: none;
+}
+
+.search-form {
+  text-align: center;
+}
+
+.search-field {
+  width: 96%;
+  padding: 12px 2% 12px 2%;
+}
+
+footer {
+  clear: both;
+}
+
+@media only screen and (min-width: 761px) {
+  .e2d3_child {
+    width: 100%;
+    max-width: 1170px;
+    margin: 0 auto;
+    margin-bottom: 100px;
+    overflow: auto;
+    padding-top: 80px;
+  }
+  .e2d3_child .module {
+    border-bottom: none;
+  }
+  .e2d3_child .module-inner {
+    max-width: inherit;
+    padding-top: 0;
+  }
+  .e2d3_child .e2d3-page-content {
+    width: 75%;
+    float: left;
+  }
+  .e2d3_child .e2d3-sidebar {
+    width: 25%;
+    float: left;
+    border-left: 1px solid rgba(0, 0, 0, 0.05);
+  }
+  .e2d3_child input[type="submit"].wpcf7-submit {
+    margin: 0 auto;
+    width: 200px;
+  }
+  .listpost-content-wrap {
+    float: none;
+    margin-top: 0;
+  }
+  .post-img-wrap {
+    width: auto;
+    margin-right: 20px;
+  }
+  .post-img-wrap a {
+    width: 200px;
+    height: 200px;
+  }
+  .e2d3_archive .entry-footer {
+    padding-top: 10px;
+  }
+}


### PR DESCRIPTION
以下、変更点です。
・トップページのお知らせ部分を「お知らせ」カテゴリーの最新２件の投稿を取得して表示させるよう変更
・トップページのイベント部分を、イベント登録用プラグインで登録したイベント情報を取得して表示させるように変更
・子ページの場合に読み込ませる子ページ用のCSSとSCSSの作成
・子ページ（投稿ページ）のテンプレート作成
・アーカイブページ（カテゴリー別、月別など）のテンプレート作成
・検索ページ（検索フォームの結果を表示するページ）のテンプレート作成
・サイドバーで表示させる検索フォーム用のテンプレート作成
→子ページのサイドバーに何を表示させるかは管理画面＞外観＞ウィジェット
・functions.phpの作成。下記処理を記述
　１）サイドバーを利用可能にする（デフォルトではウィジェットは無効となっている）
　２）子ページかどうかを判断して、子ページの場合に子ページ用のCSSを読み込ませる
　３）検索フォームで検索した際に、新着順で通常の投稿のみを表示させる
　４）アーカイブページにて、本文の抜粋部分の最後に、デフォルトでは「more」と表示されるものを「…」に変更
　５）記事投稿時にサムネイルをアップロードした場合に、画像をサムネイル用にリサイズする処理