### PR TITLE
【過去のイベント】過去のイベントを関数で取得・表示

### DIFF
--- a/wp-content/themes/e2d3-web/front-page.php
+++ b/wp-content/themes/e2d3-web/front-page.php
@@ -160,27 +160,8 @@
 
                 
                 <h3>過去のイベント</h3>
-                <ul class="eventInfo-past"><!--
-                 --><li><a href="#" style="background-image:url('http://e2d3.org/wp-content/uploads/2017/11/23032921_10214709510551805_3844396104476802665_n.jpg')">
-                        <dl class="eventInfo-description">
-                            <dd class="desc-date">2017/12/20</dd>
-                            <dt class="desc-eventTitle">【E2D3】データビジュアライゼーションもくもく会VOL.7！</dt>
-                        </dl>
-                    </a></li><!--
-                 --><li><a href="#" style="background-image:url('http://e2d3.org/wp-content/uploads/2017/07/7dbdc58c5b5ad8ec94742b50dee94973147a7805-2.png')">
-                        <dl class="eventInfo-description">
-                            <dd class="desc-date">2017/12/20</dd>
-                            <dt class="desc-eventTitle">【E2D3】データビジュアライゼーションもくもく会VOL.7！</dt>
-                        </dl>
-                    </a></li><!--
-                 --><li><a href="#" style="background-image:url('')">
-                        <dl class="eventInfo-description">
-                            <dd class="desc-date">2017/12/20</dd>
-                            <dt class="desc-eventTitle">【E2D3】データビジュアライゼーションもくもく会VOL.7！</dt>
-                        </dl>
-                    </a></li><!--
-             --></ul>
-             <p class="buttonLink"><a href="#anchor-detailE2D3">過去のイベント一覧</a></p>
+                <?php show_past_event(); ?>
+                                
             </div>
         </section>
 

--- a/wp-content/themes/e2d3-web/functions.php
+++ b/wp-content/themes/e2d3-web/functions.php
@@ -237,6 +237,46 @@ endif;
     wp_reset_postdata();
 }
 
+// 過去のイベント最新３件＆一覧へのリンク
+function show_past_event(){
+
+  $pastEv = new WP_Query(array(
+    'category_name'=>'News',
+    'post_status'=>'publish',
+    'orderby'=>'date',
+    'order'=>'DESC',
+    'posts_per_page'=>'3'
+  ));
+  $pastEvID = $pastEv->get_queried_object_id();
+  
+  if($pastEv->have_posts()):
+    ?>
+    <ul class="eventInfo-past" style="font-size:0;">
+    <?php 
+    while($pastEv->have_posts()):$pastEv->the_post(); ?>
+    <li>
+    
+      <a href="<?php the_permalink(); ?>" style="background-image:url('<?php the_post_thumbnail_url(); ?>')">
+      <dl class="eventInfo-description">
+          <dd class="desc-date"><?php echo get_post_time('Y/m/d'); ?></dd>
+          <dt class="desc-eventTitle"><?php the_title(); ?></dt>
+      </dl>
+      </a>
+    </li>
+    <?php 
+    endwhile;
+    ?>
+    </ul>
+    <p class="buttonLink">
+      <a href="<?php echo esc_url(get_category_link($pastEvID)); ?>">過去のイベント一覧</a>
+    </p>
+  <?php
+  endif;   
+
+  wp_reset_postdata();
+  
+}
+
 /* ↑↑for ChildPage↑↑ */
 
 ?>


### PR DESCRIPTION
修正ファイルと修正内容

・functions.php
→ 関数show_past_eventを追加
・front-page.php
→ 過去のイベントの <ul>タグと一覧へのリンクをphpの関数の呼び出しへ置き換え

カテゴリー「News」の最新３件を取得・表示させています。
（後々「News」ではなく「Event」から取得するように変更するイメージ）